### PR TITLE
Support gpu with machine type

### DIFF
--- a/pkg/service/azure/cluster.go
+++ b/pkg/service/azure/cluster.go
@@ -15,8 +15,6 @@ import (
 	proto "gitlab.com/netbook-devs/spawner-service/proto/netbookai/spawner"
 )
 
-const testpubkey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDL67TCv+MyUnT0gHUl2xpJF56TjCkcTKkXUjhIaUDY/gv/bFm5pVbvrHovKV/W2MrI5e9Ix2iQIiityWVABFEFWe7m0yx3ds49ZkM3kIflsqmPeywCcN8V2bMsiVwyrLBsboeRcbQyJJIrsb8A0mj3ooWFfT44I42YVCg4FOTsB+wmlthawBlMGKzZb8ITUMaN0VCtXfIslg6ptQHtficL/N1HW7FSXXiZPJaRi3kuCH18e/wCkP4eomWMZ6MQC1CIwGIkfh9K4pfuppfZ9HG+jyw0ha0LZ6utDbEULMPAtvgUZXB7+1vk1NTwi78p558Dk6fxWGRVgSQu7Qk4yddZ nishanth@nishanth-Legion-5-15ACH6"
-
 func (a *AzureController) createCluster(ctx context.Context, req *proto.ClusterRequest) (*proto.ClusterResponse, error) {
 
 	clusterName := req.ClusterName

--- a/pkg/service/azure/node.go
+++ b/pkg/service/azure/node.go
@@ -91,7 +91,9 @@ func (a AzureController) addNode(ctx context.Context, req *proto.NodeSpawnReques
 		OsDiskSizeGB: &req.NodeSpec.DiskSize,
 	}
 
-	if req.NodeSpec.GpuEnabled && req.NodeSpec.MigProfile != proto.MIGProfile_UNKNOWN {
+	isGpu := common.IsGPU(req.NodeSpec.MachineType) || req.NodeSpec.GpuEnabled
+
+	if isGpu && req.NodeSpec.MigProfile != proto.MIGProfile_UNKNOWN {
 		mcappp.GpuInstanceProfile = getGPUProfile(req.NodeSpec.MigProfile) // containerservice.GPUInstanceProfileMIG1g
 	}
 

--- a/pkg/service/common/machine.go
+++ b/pkg/service/common/machine.go
@@ -21,6 +21,7 @@ const XLv100 = "xl+v100"
 type InstanceSizeMap map[string]string
 
 var providerInstanceType map[string]InstanceSizeMap
+var gpus map[string]bool
 
 func azure() InstanceSizeMap {
 	m := InstanceSizeMap{
@@ -80,6 +81,16 @@ func init() {
 	providerInstanceType[constants.AzureLabel] = azure()
 	providerInstanceType[constants.AwsLabel] = aws()
 	providerInstanceType[constants.GcpLabel] = gcp()
+
+	gpus = map[string]bool{
+		MT4:    true,
+		Mk80:   true,
+		Lk80:   true,
+		XLk80:  true,
+		Mv100:  true,
+		Lv100:  true,
+		XLv100: true,
+	}
 }
 
 //GetInstance given machine size return the exact instance type for the provider
@@ -93,4 +104,8 @@ func GetInstance(provider, machine string) string {
 		return t
 	}
 	return ""
+}
+
+func IsGPU(m string) bool {
+	return gpus[m]
 }

--- a/pkg/service/common/machine.go
+++ b/pkg/service/common/machine.go
@@ -21,7 +21,7 @@ const XLv100 = "xl+v100"
 type InstanceSizeMap map[string]string
 
 var providerInstanceType map[string]InstanceSizeMap
-var gpus map[string]bool
+var gpus map[string]struct{}
 
 func azure() InstanceSizeMap {
 	m := InstanceSizeMap{
@@ -82,14 +82,14 @@ func init() {
 	providerInstanceType[constants.AwsLabel] = aws()
 	providerInstanceType[constants.GcpLabel] = gcp()
 
-	gpus = map[string]bool{
-		MT4:    true,
-		Mk80:   true,
-		Lk80:   true,
-		XLk80:  true,
-		Mv100:  true,
-		Lv100:  true,
-		XLv100: true,
+	gpus = map[string]struct{}{
+		MT4:    {},
+		Mk80:   {},
+		Lk80:   {},
+		XLk80:  {},
+		Mv100:  {},
+		Lv100:  {},
+		XLv100: {},
 	}
 }
 
@@ -107,5 +107,6 @@ func GetInstance(provider, machine string) string {
 }
 
 func IsGPU(m string) bool {
-	return gpus[m]
+	_, ok := gpus[m]
+	return ok
 }

--- a/pkg/service/common/machine_test.go
+++ b/pkg/service/common/machine_test.go
@@ -22,4 +22,7 @@ func Test_GetInstance(t *testing.T) {
 
 	got = GetInstance("gcp", "m+v1000")
 	assert.Equal(t, "", got, "GetInstance: for invalid machine size")
+
+	assert.True(t, IsGPU(Lk80), "expected gpu machine")
+	assert.False(t, IsGPU(M), "expected non-gpu machine")
 }

--- a/pkg/service/labels/labels.go
+++ b/pkg/service/labels/labels.go
@@ -2,6 +2,7 @@ package labels
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"gitlab.com/netbook-devs/spawner-service/pkg/config"
@@ -25,6 +26,8 @@ func GetNodeLabel(nodeSpec *proto.NodeSpec) map[string]*string {
 	instance := ""
 	if nodeSpec.MachineType != "" {
 		instance = nodeSpec.MachineType
+		//+ is not allowed in tag value regex
+		instance = strings.Replace(instance, "+", "-", 2)
 	}
 	if nodeSpec.Instance != "" {
 		instance = nodeSpec.Instance


### PR DESCRIPTION
# Description

check if gpu enabled when using machine type instead of instances.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# why

When we use machine type, some set of types are supported for gpu, which wasnt accounted in creatig nodes with machine type request.

# How Has This Been Tested?

manual


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
