### PR TITLE
refactor labels, namespace all labels created by spawner with 'netbook.ai'

### DIFF
--- a/pkg/service/aws/cluster.go
+++ b/pkg/service/aws/cluster.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/pkg/errors"
-	"gitlab.com/netbook-devs/spawner-service/pkg/service/constants"
 	"gitlab.com/netbook-devs/spawner-service/pkg/service/labels"
 	proto "gitlab.com/netbook-devs/spawner-service/proto/netbookai/spawner"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -58,7 +57,7 @@ func (svc AWSController) createClusterInternal(ctx context.Context, session *Ses
 	}
 
 	tags := labels.DefaultTags()
-	tags[constants.ClusterNameLabel] = &clusterName
+	tags[labels.TagKey(labels.ClusterNameLabel)] = &clusterName
 	//override with additional labels from request
 	for k, v := range req.Labels {
 		v := v
@@ -207,17 +206,17 @@ func (ctrl AWSController) GetClusters(ctx context.Context, req *proto.GetCluster
 			continue
 
 		}
-		creator, ok := clusterSpec.Tags[constants.CreatorLabel]
+		creator, ok := clusterSpec.Tags[labels.TagKey(labels.CreatorLabel)]
 		if !ok {
 			//unknown creator
 			continue
 		}
 
-		if *clusterSpec.Status != "ACTIVE" || *creator != constants.SpawnerServiceLabel {
+		if *clusterSpec.Status != "ACTIVE" || *creator != labels.SpawnerServiceLabel {
 			continue
 		}
 
-		scope, ok := clusterSpec.Tags[constants.Scope]
+		scope, ok := clusterSpec.Tags[labels.TagKey(labels.Scope)]
 		if !ok {
 			continue
 		}
@@ -302,7 +301,7 @@ func (ctrl AWSController) GetCluster(ctx context.Context, req *proto.GetClusterR
 
 	var nodeSpecList []*proto.NodeSpec
 	for _, node := range nodeList.Items {
-		nodeGroupName := node.Labels[constants.NodeNameLabel]
+		nodeGroupName := node.Labels[labels.TagKey(labels.NodeNameLabel)]
 		addresses := node.Status.Addresses
 		ipAddr := ""
 		hostName := node.Name
@@ -400,7 +399,7 @@ func (ctrl AWSController) DeleteCluster(ctx context.Context, req *proto.ClusterD
 		return nil, errors.Wrap(err, "DeleteCluster: ")
 	}
 
-	if scope, ok := cluster.Tags[constants.Scope]; !ok || *scope != labels.ScopeTag() {
+	if scope, ok := cluster.Tags[labels.TagKey(labels.Scope)]; !ok || *scope != labels.ScopeTag() {
 		return nil, fmt.Errorf("cluster doesnt not available in '%s'", labels.ScopeTag())
 	}
 

--- a/pkg/service/aws/node.go
+++ b/pkg/service/aws/node.go
@@ -396,7 +396,7 @@ func (ctrl AWSController) DeleteNode(ctx context.Context, req *proto.NodeDeleteR
 		return nil, err
 	}
 
-	if scope, ok := nodeGroup.Nodegroup.Tags[constants.Scope]; !ok || *scope != labels.ScopeTag() {
+	if scope, ok := nodeGroup.Nodegroup.Tags[labels.TagKey(labels.Scope)]; !ok || *scope != labels.ScopeTag() {
 		ctrl.logger.Errorw("nodegroup is not available in scope", "scope", labels.ScopeTag())
 		return nil, fmt.Errorf("nodegroup '%s' not available in scope '%s'", nodeName, labels.ScopeTag())
 	}

--- a/pkg/service/aws/role.go
+++ b/pkg/service/aws/role.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
-	"gitlab.com/netbook-devs/spawner-service/pkg/service/constants"
 	"gitlab.com/netbook-devs/spawner-service/pkg/service/labels"
 )
 
@@ -22,6 +21,11 @@ func (svc AWSController) createRoleOrGetExisting(ctx context.Context, iamClient 
 		return role.Role, false, nil
 
 	}
+
+	key := func(k string) *string {
+		return aws.String(labels.TagKey(k))
+	}
+
 	//role not found, create it
 	if aerr, ok := err.(awserr.Error); ok && aerr.Code() == iam.ErrCodeNoSuchEntityException {
 		svc.logger.Warnf("failed to get role '%s', creating new role", roleName)
@@ -33,15 +37,15 @@ func (svc AWSController) createRoleOrGetExisting(ctx context.Context, iamClient 
 			Description:              &description,
 			Tags: []*iam.Tag{
 				{
-					Key:   aws.String(constants.CreatorLabel),
-					Value: aws.String(constants.SpawnerServiceLabel),
+					Key:   key(labels.CreatorLabel),
+					Value: aws.String(labels.SpawnerServiceLabel),
 				},
 				{
-					Key:   aws.String(constants.NameLabel),
+					Key:   key(labels.NameLabel),
 					Value: &roleName,
 				},
 				{
-					Key:   aws.String(constants.Scope),
+					Key:   key(labels.Scope),
 					Value: aws.String( /*(internal)aws.*/ labels.ScopeTag()),
 				},
 			},

--- a/pkg/service/azure/client.go
+++ b/pkg/service/azure/client.go
@@ -7,7 +7,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/containerservice/mgmt/containerservice"
 	"github.com/Azure/azure-sdk-for-go/services/costmanagement/mgmt/2019-11-01/costmanagement"
 	"gitlab.com/netbook-devs/spawner-service/pkg/service/azure/iam"
-	"gitlab.com/netbook-devs/spawner-service/pkg/service/constants"
+	"gitlab.com/netbook-devs/spawner-service/pkg/service/labels"
 	"gitlab.com/netbook-devs/spawner-service/pkg/service/system"
 )
 
@@ -19,7 +19,7 @@ func getAKSClient(c *system.AzureCredential) (*containerservice.ManagedClustersC
 		return nil, err
 	}
 	aksClient.Authorizer = auth
-	aksClient.AddToUserAgent(constants.SpawnerServiceLabel)
+	aksClient.AddToUserAgent(labels.SpawnerServiceLabel)
 	aksClient.PollingDuration = time.Hour * 1
 	aksClient.RetryAttempts = 1
 	return &aksClient, nil
@@ -34,7 +34,7 @@ func getCostManagementClient(c *system.AzureCredential) (*costmanagement.QueryCl
 	}
 	costmgmtClient.Authorizer = auth
 	costmgmtClient.RetryAttempts = 1
-	costmgmtClient.AddToUserAgent(constants.SpawnerServiceLabel)
+	costmgmtClient.AddToUserAgent(labels.SpawnerServiceLabel)
 
 	return &costmgmtClient, nil
 }
@@ -47,7 +47,7 @@ func getAgentPoolClient(c *system.AzureCredential) (*containerservice.AgentPools
 		return nil, err
 	}
 	agentClient.Authorizer = auth
-	agentClient.AddToUserAgent(constants.SpawnerServiceLabel)
+	agentClient.AddToUserAgent(labels.SpawnerServiceLabel)
 	agentClient.PollingDuration = time.Hour * 1
 	return &agentClient, nil
 }
@@ -60,7 +60,7 @@ func getDisksClient(c *system.AzureCredential) (*compute.DisksClient, error) {
 		return nil, err
 	}
 	dc.Authorizer = a
-	dc.AddToUserAgent(constants.SpawnerServiceLabel)
+	dc.AddToUserAgent(labels.SpawnerServiceLabel)
 	return &dc, nil
 }
 
@@ -72,6 +72,6 @@ func getSnapshotClient(c *system.AzureCredential) (*compute.SnapshotsClient, err
 		return nil, err
 	}
 	sc.Authorizer = a
-	sc.AddToUserAgent(constants.SpawnerServiceLabel)
+	sc.AddToUserAgent(labels.SpawnerServiceLabel)
 	return &sc, nil
 }

--- a/pkg/service/constants/constant.go
+++ b/pkg/service/constants/constant.go
@@ -4,24 +4,10 @@ package constants
 //calling StrPtr() or aws.String() seems like repetetive
 
 var (
-	NameLabel           = "Name" //Capital N for Aws
-	CreatorLabel        = "creator"
-	SpawnerServiceLabel = "spawner-service"
-	Scope               = "scope"
-
-	ProvisionerLabel         = "provisioner"
-	ClusterNameLabel         = "cluster-name"
-	WorkspaceLabel           = "workspaceid"
-	NodeNameLabel            = "node-name"
-	InstanceLabel            = "instance"
-	NodeLabelSelectorLabel   = "nodeLabelSelector"
-	AwsLabel                 = "aws"
-	VpcTagKey                = "vpc"
-	NBTypeTagkey             = "nb-type"
-	NBRegionWkspNetworkStack = "nb-region-ntwk-stk"
-	WorkspaceId              = "workspaceid"
-	AzureLabel               = "azure"
-	GcpLabel                 = "gcp"
+	WorkspaceId = "workspaceid"
+	AwsLabel    = "aws"
+	AzureLabel  = "azure"
+	GcpLabel    = "gcp"
 )
 
 type CloudProvider string

--- a/pkg/service/labels/constants.go
+++ b/pkg/service/labels/constants.go
@@ -1,0 +1,21 @@
+package labels
+
+const (
+	NameLabel = "Name" //Capital N for Aws
+
+	CreatorLabel        = "creator"
+	SpawnerServiceLabel = "spawner-service"
+	Scope               = "scope"
+
+	ProvisionerLabel         = "provisioner"
+	ClusterNameLabel         = "cluster-name"
+	NodeNameLabel            = "node-name"
+	InstanceLabel            = "instance"
+	NodeLabelSelectorLabel   = "nodeLabelSelector"
+	VpcTagKey                = "vpc"
+	NBTypeTagkey             = "nb-type"
+	NBRegionWkspNetworkStack = "nb-region-ntwk-stk"
+	//WorkspaceLabel           = "workspaceid"
+
+	LabelNamespace = "netbook.ai"
+)

--- a/pkg/service/labels/labels.go
+++ b/pkg/service/labels/labels.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"gitlab.com/netbook-devs/spawner-service/pkg/config"
-	"gitlab.com/netbook-devs/spawner-service/pkg/service/constants"
 	proto "gitlab.com/netbook-devs/spawner-service/proto/netbookai/spawner"
 )
 
@@ -19,6 +18,10 @@ func merge(maps ...map[string]*string) map[string]*string {
 		}
 	}
 	return m
+}
+
+func TagKey(k string) string {
+	return fmt.Sprintf("%s/%s", LabelNamespace, k)
 }
 
 func GetNodeLabel(nodeSpec *proto.NodeSpec) map[string]*string {
@@ -34,10 +37,10 @@ func GetNodeLabel(nodeSpec *proto.NodeSpec) map[string]*string {
 	}
 
 	labels := map[string]*string{
-		constants.NodeNameLabel:          &nodeSpec.Name,
-		constants.InstanceLabel:          &instance,
-		constants.NodeLabelSelectorLabel: &nodeSpec.Name,
-		"type":                           aws.String("nodegroup")}
+		TagKey(NodeNameLabel):          &nodeSpec.Name,
+		TagKey(InstanceLabel):          &instance,
+		TagKey(NodeLabelSelectorLabel): &nodeSpec.Name,
+		TagKey("type"):                 aws.String("nodegroup")}
 
 	return merge(DefaultTags(), labels, aws.StringMap(nodeSpec.Labels))
 }
@@ -50,7 +53,7 @@ func ScopeTag() string {
 func DefaultTags() map[string]*string {
 	scope := ScopeTag()
 	return map[string]*string{
-		constants.Scope:        &scope,
-		constants.CreatorLabel: &constants.SpawnerServiceLabel,
+		TagKey(Scope):        &scope,
+		TagKey(CreatorLabel): aws.String(SpawnerServiceLabel),
 	}
 }


### PR DESCRIPTION
# Description

Add tags to resources created by spawner by namespacing it under `netbook.ai/`.
Refactor label constants.

This change requires to change existing resources with updated tag key with the namespace/(prefix), spawner will fail to recognise the resources already created prior this change.

following resources/tags must be changed to new format,
- `scope` changed to `netbook.ai/scope`
- all tags in vpc, subnet must have all of its tags prefixed `netbook.ai/XXX` except tag `Name`.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# why
- enable user to setup the tags they need without conflicting with spawner labels.

# How Has This Been Tested?

Manually tested.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
