### PR TITLE
add logs to network stack

### DIFF
--- a/pkg/service/aws/cluster.go
+++ b/pkg/service/aws/cluster.go
@@ -28,7 +28,7 @@ func (svc awsController) createClusterInternal(ctx context.Context, session *Ses
 	var subnetIds []*string
 	region := session.Region
 
-	awsRegionNetworkStack, err := GetRegionWkspNetworkStack(session)
+	awsRegionNetworkStack, err := GetRegionWkspNetworkStack(ctx, session, svc.logger)
 	if err != nil {
 		svc.logger.Error(ctx, "error getting network stack for region", "region", region, "error", err)
 		return nil, err
@@ -40,6 +40,7 @@ func (svc awsController) createClusterInternal(ctx context.Context, session *Ses
 		}
 		svc.logger.Info(ctx, "got network stack for region", "vpc", awsRegionNetworkStack.Vpc.VpcId, "subnets", subnetIds)
 	} else {
+		svc.logger.Info(ctx, "did not find any network stack in region", "region", region)
 		awsRegionNetworkStack, err = CreateRegionWkspNetworkStack(session)
 		if err != nil {
 			svc.logger.Error(ctx, "error creating network stack for region with no clusters", "region", region, "error", err)


### PR DESCRIPTION
# Description

Add extensvie logs to get network stack calls.

## Type of change

- [x] Improvent/enhancement
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# why
- its hard to debug the issue when spawnr fails to fetch the network stack.
- add more logs, warning to pin point what component of network stack has issue or not able to get.
- 
# How Has This Been Tested?

- 

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
