### PR TITLE
Added support for user's home directory aws creds

### DIFF
--- a/pkg/service/aws/session.go
+++ b/pkg/service/aws/session.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"context"
 	"encoding/base64"
-	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -40,32 +39,17 @@ func NewSession(ctx context.Context, region string, accountName string) (*Sessio
 
 	conf := config.Get()
 	if conf.Env == "local" {
-		log.Println("running in dev mode, using ", conf.AWSAccessID)
+		sess, err := system.GetLocalEnvSession(region)
 
-		if conf.AWSAccessID != "" {
-			// creating creds from config variables
-			awsCreds = credentials.NewStaticCredentials(conf.AWSAccessID, conf.AWSSecretKey, conf.AWSToken)
-
-		} else {
-
-			log.Println("AWS_ACCESS_ID is empty, using 'default' profile from user's home directory")
-			// looking for creds in user's home directory with "default" profile
-			sess, err := session.NewSessionWithOptions(
-				session.Options{
-					Profile: "default",
-				},
-			)
-			if err != nil {
-				log.Println("ERROR: provide AWS creds in config file")
-				return nil, err
-			}
-
-			return &Session{
-				AwsSession: sess,
-				Region:     region,
-				TeamId:     accountName,
-			}, nil
+		if err != nil {
+			return nil, err
 		}
+
+		return &Session{
+			AwsSession: sess,
+			Region:     region,
+			TeamId:     accountName,
+		}, nil
 
 	} else {
 		//secret manager is hosted in particular region, all writes happen to the same region

--- a/pkg/service/aws/session.go
+++ b/pkg/service/aws/session.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 	"encoding/base64"
+	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -14,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/pkg/errors"
 	"gitlab.com/netbook-devs/spawner-service/pkg/config"
 	"gitlab.com/netbook-devs/spawner-service/pkg/service/system"
 	"k8s.io/client-go/dynamic"
@@ -28,6 +30,57 @@ type Session struct {
 	TeamId     string
 }
 
+func getSessionUsingAwsAccessKey(region string) (*session.Session, error) {
+
+	conf := config.Get()
+
+	cred := credentials.NewStaticCredentials(conf.AWSAccessID, conf.AWSSecretKey, conf.AWSToken)
+
+	sess, err := session.NewSession(&aws.Config{
+		Region:      aws.String(region),
+		Credentials: cred,
+	})
+
+	return sess, err
+}
+
+func getSessionUsingAwsProfile(profile string) (*session.Session, error) {
+
+	sess, err := session.NewSessionWithOptions(
+		session.Options{
+			Profile: profile,
+		},
+	)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to find the credential config in system")
+	}
+
+	//NewSessionWithOptions doesn't return error if we pass the invalid profile, checking here
+	// if we got the credentials correctly
+	_, err = sess.Config.Credentials.Get()
+
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to find the credential config in system")
+	}
+
+	return sess, nil
+
+}
+
+func getLocalEnvSession(region string) (*session.Session, error) {
+
+	if config.Get().AWSAccessID != "" {
+		// creating creds from config variables
+		return getSessionUsingAwsAccessKey(region)
+
+	}
+
+	log.Println("AWSAccessID is empty, using 'default' profile from user's home directory")
+	return getSessionUsingAwsProfile("default")
+
+}
+
 //NewSession create a session for given user account by fetching user credentials from the secret stores.
 // if running locally and env set to local, it will use credentials from the config
 func NewSession(ctx context.Context, region string, accountName string) (*Session, error) {
@@ -39,7 +92,7 @@ func NewSession(ctx context.Context, region string, accountName string) (*Sessio
 
 	conf := config.Get()
 	if conf.Env == "local" {
-		sess, err := system.GetLocalEnvSession(region)
+		sess, err := getLocalEnvSession(region)
 
 		if err != nil {
 			return nil, err

--- a/pkg/service/system/secrets.go
+++ b/pkg/service/system/secrets.go
@@ -77,7 +77,26 @@ func createSession(region string) (*session.Session, error) {
 
 	if conf.Env == "local" {
 		log.Println("running in dev mode, using ", conf.AWSAccessID)
-		cred = credentials.NewStaticCredentials(conf.AWSAccessID, conf.AWSSecretKey, conf.AWSToken)
+
+		if conf.AWSAccessID != "" {
+			// creating creds from config variables
+			cred = credentials.NewStaticCredentials(conf.AWSAccessID, conf.AWSSecretKey, conf.AWSToken)
+		} else {
+
+			log.Println("AWSAccessID is empty, using 'default' profile from user's home directory")
+			// looking for creds in user's home directory with "default" profile
+			sess, err := session.NewSessionWithOptions(
+				session.Options{
+					Profile: "default",
+				},
+			)
+			if err != nil {
+				log.Println("ERROR: provide AWS creds in config file")
+				return nil, err
+			}
+
+			return sess, nil
+		}
 
 	} else {
 		stsCreds, stserr := getSystemCredential()


### PR DESCRIPTION
# Description

If AWS credentials are not provided in config file, spawner will try to use 'default'  aws profile from user's home directory

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# why

# How Has This Been Tested?
- Tested using testclient
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
