### PR TITLE
fix CreateRoute53Records to upsert, unquote route53 record values in GetRoute53TXTRecords

### DIFF
--- a/pkg/service/system/route53.go
+++ b/pkg/service/system/route53.go
@@ -249,9 +249,12 @@ func GetRoute53TXTRecords(ctx context.Context) ([]types.Route53ResourceRecordSet
 		}
 
 		for _, rr := range recordSet.ResourceRecords {
-
+			unquotedStr, err := strconv.Unquote(*rr.Value)
+			if err != nil {
+				return nil, errors.Wrap(err, "GetRoute53Records: failed to unquote route53 records")
+			}
 			resourceRecordSet.ResourceRecords = append(resourceRecordSet.ResourceRecords, types.ResourceRecordValue{
-				Value: *rr.Value,
+				Value: unquotedStr,
 			})
 		}
 
@@ -265,7 +268,7 @@ func GetRoute53TXTRecords(ctx context.Context) ([]types.Route53ResourceRecordSet
 // CreateRoute53Records creates new records in the zone
 func CreateRoute53Records(ctx context.Context, records []types.Route53ResourceRecordSet) error {
 
-	err := applyChange(ctx, records, route53.ChangeActionCreate)
+	err := applyChange(ctx, records, route53.ChangeActionUpsert)
 
 	if err != nil {
 		return errors.Wrap(err, "CreateRoute53Records: failed to create record")


### PR DESCRIPTION
# Description

- fixing CreateRoute53Records  to use `upsert` instead of `create`
- to maintain uniformity unquoting record values in GetRoute53TXTRecords, in CreateRoute53Records we are expecting plain strings and quoting them before passing to AWS

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# why

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
