### PR TITLE
missing region when creation session with user home cred

### DIFF
--- a/pkg/service/aws/session.go
+++ b/pkg/service/aws/session.go
@@ -44,10 +44,11 @@ func getSessionUsingAwsAccessKey(region string) (*session.Session, error) {
 	return sess, err
 }
 
-func getSessionUsingAwsProfile(profile string) (*session.Session, error) {
+func getSessionUsingAwsProfile(profile, region string) (*session.Session, error) {
 
 	sess, err := session.NewSessionWithOptions(
 		session.Options{
+			Config:  aws.Config{Region: &region},
 			Profile: profile,
 		},
 	)
@@ -77,7 +78,7 @@ func getLocalEnvSession(region string) (*session.Session, error) {
 	}
 
 	log.Println("AWSAccessID is empty, using 'default' profile from user's home directory")
-	return getSessionUsingAwsProfile("default")
+	return getSessionUsingAwsProfile("default", region)
 
 }
 

--- a/pkg/service/system/secrets.go
+++ b/pkg/service/system/secrets.go
@@ -83,10 +83,11 @@ func getSessionUsingAwsAccessKey(region string) (*session.Session, error) {
 	return sess, err
 }
 
-func getSessionUsingAwsProfile(profile string) (*session.Session, error) {
+func getSessionUsingAwsProfile(profile, region string) (*session.Session, error) {
 
 	sess, err := session.NewSessionWithOptions(
 		session.Options{
+			Config:  aws.Config{Region: &region},
 			Profile: profile,
 		},
 	)
@@ -112,11 +113,10 @@ func getLocalEnvSession(region string) (*session.Session, error) {
 	if config.Get().AWSAccessID != "" {
 		// creating creds from config variables
 		return getSessionUsingAwsAccessKey(region)
-
 	}
 
 	log.Println("AWSAccessID is empty, using 'default' profile from user's home directory")
-	return getSessionUsingAwsProfile("default")
+	return getSessionUsingAwsProfile("default", region)
 
 }
 


### PR DESCRIPTION
# Description

Use region when creating a session from the credentials in user system

Fixes #65 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# why


# How Has This Been Tested?

- tested calling cluster-status as reported in issue
# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
