### PR TITLE
show warning when oidc provider not found as we ignore the error and create new

### DIFF
--- a/pkg/service/aws/oidc.go
+++ b/pkg/service/aws/oidc.go
@@ -237,7 +237,7 @@ func (a *awsController) RegisterClusterOIDC(ctx context.Context, req *proto.Regi
 	})
 
 	if err != nil {
-		a.logger.Error(ctx, "failed to fetch open id provider", "error", err)
+		a.logger.Warn(ctx, "failed to fetch open id provider", "error", err)
 
 		a.logger.Info(ctx, "generating OIDC thumbprint ", "issuer", issuer)
 		thumbprint, err := getOIDCThumbprint(ctx, issuer) //sample: "9e99a48a9960b14926bb7f3b02e22da2b0ab7280"


### PR DESCRIPTION
# Description

We check if we have already created oidc provider for the cluster, if not we create new  one. Update the logger from Error level to Warn in this case

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# why

- this is not an actionable error, 

# How Has This Been Tested?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
